### PR TITLE
[Chore] #32 - 홈뷰 웹툰리스트 레이아웃 수정

### DIFF
--- a/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/Cell/AllToonsSectionCell.swift
+++ b/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/Cell/AllToonsSectionCell.swift
@@ -16,13 +16,12 @@ class AllToonsSectionCell: UICollectionViewCell {
         let imageView = UIImageView(frame: .zero)
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
-        imageView.setupCornerRadius(<#T##radius: CGFloat##CGFloat#>)
+        imageView.setupCornerRadius(8)
         return imageView
     }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.contentView.backgroundColor = .gray
         
         setupHierarchy()
         setupLayout()

--- a/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/Cell/AllToonsSectionCell.swift
+++ b/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/Cell/AllToonsSectionCell.swift
@@ -16,6 +16,7 @@ class AllToonsSectionCell: UICollectionViewCell {
         let imageView = UIImageView(frame: .zero)
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
+        imageView.setupCornerRadius(<#T##radius: CGFloat##CGFloat#>)
         return imageView
     }()
     

--- a/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/View/HomeView.swift
+++ b/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/View/HomeView.swift
@@ -107,7 +107,7 @@ class HomeView: UIView {
     private func allToonsSection() -> NSCollectionLayoutSection {
         
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute((UIScreen.main.bounds.width-22-8)/3), heightDimension: .estimated(230)
+            widthDimension: .absolute((UIScreen.main.bounds.width-22-8)/3), heightDimension: .absolute(230)
         )
         
         let item = NSCollectionLayoutItem(

--- a/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/View/HomeView.swift
+++ b/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/View/HomeView.swift
@@ -107,13 +107,12 @@ class HomeView: UIView {
     private func allToonsSection() -> NSCollectionLayoutSection {
         
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(115), heightDimension: .estimated(230)
+            widthDimension: .absolute((UIScreen.main.bounds.width-22-8)/3), heightDimension: .estimated(230)
         )
         
         let item = NSCollectionLayoutItem(
             layoutSize: itemSize
         )
-        item.contentInsets.leading = 4
         
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(230)
@@ -123,11 +122,13 @@ class HomeView: UIView {
             layoutSize: groupSize, subitems: [item, item, item]
         )
         
+        group.interItemSpacing = NSCollectionLayoutSpacing.fixed(4)
+        
         let section = NSCollectionLayoutSection(
             group: group
         )
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 0, leading: 0, bottom: 0, trailing: 0
+            top: 0, leading: 11, bottom: 0, trailing: 11
         )
         section.interGroupSpacing = 4
         

--- a/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/KAKAOWEBTOON-iOS/KAKAOWEBTOON-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -112,7 +112,7 @@ class HomeViewController: UIViewController, UICollectionViewDataSource, UICollec
             else {
                 return UICollectionViewCell()
             }
-            cell.configure(with: .init(title: "sss", image: .imgHomeCharcter))
+            cell.configure(with: .init(title: "sss", image: .imgHomeBackground))
             return cell
         }
     }


### PR DESCRIPTION
## 👾 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 홈뷰 웹툰리스트 레이아웃을 수정했습니다.
## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
```swift
        let itemSize = NSCollectionLayoutSize(
            widthDimension: .absolute((UIScreen.main.bounds.width-22-8)/3), heightDimension: .absolute(230)
        )
```
웹툰 이미지를 그리는 item을 위와 같이 화면의 너비에서 spacing 값을 빼고 3등분으로 나눈 값으로 설정했습니다.
</br>
```swift
group.interItemSpacing = NSCollectionLayoutSpacing.fixed(4)
```
기존 item간의 간격을 leading -> interItemSpaing으로 변경했습니다.
## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| iPhone16 pro | ![simulator_screenshot_79BC8715-6560-42F8-87EE-F47176CE1BDC](https://github.com/user-attachments/assets/f8a03c66-45b9-4be5-913f-78847cbba97f) |
### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #32 
